### PR TITLE
fix: remove SPA rewrite rule from vercel.jsonfix: remove SPA rewrite rule from vercel.jsonfix: remove SPA rewrite …

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,10 +8,6 @@
     {
       "source": "/api/(.*)",
       "destination": "/api/index.js"
-    },
-    {
-      "source": "/",
-      "destination": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
Remove the SPA rewrite rule `{ "source": "/", "destination": "/index.html" }` from vercel.json to fix Vercel routing issues.

This change:
- Removes the problematic SPA fallback routing
- Keeps only the API routing rule for proper backend functionality
- Should resolve Vercel deployment routing conflicts

**Changes made:**
- Deleted the root path rewrite rule from the rewrites array
- Maintained the `/api/(.*)` → `/api/index.js` routing rule…rule from vercel.jsonUpdate vercel.json

Remove the SPA rewrite rule { "source": "/", "destination": "/index.html" } from vercel.json to fix Vercel routing issues. Only keep the API routing rule for proper backend functionality.