### PR TITLE
fix: Move vite from devDependencies to dependencies for Vercel buildfix: Move vite from devDependencies to dependencies for Vercel buildf…

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
     "vaul": "^1.1.0",
+    "vite": "^5.4.19",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "xlsx": "^0.18.5",
@@ -133,8 +134,7 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
-    "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "typescript": "5.6.3"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
This change moves the `vite` dependency from `devDependencies` to `dependencies` to fix Vercel build issues.

Vercel's build process requires `vite` to be available as a production dependency during the build phase. This change ensures that Vercel can properly build the project.

**Changes made:**
- Moved `"vite": "^5.4.19"` from `devDependencies` to `dependencies` in `package.json`…ix: Move vite from devDependencies to dependencies for Vercel buildUpdate package.json

This change moves the vite dependency from devDependencies to dependencies to fix Vercel build issues. Vercel's build process requires vite to be available as a production dependency.